### PR TITLE
Emit on alerts so scripts can act on them

### DIFF
--- a/src/victorops.coffee
+++ b/src/victorops.coffee
@@ -187,6 +187,7 @@ class VictorOps extends Adapter
       for item in data.PAYLOAD.TIMELINE_LIST
         try
           if item.ALERT
+            @robot.emit "alert", item.ALERT
             @rcvVOEvent 'alert', item.ALERT
         catch
           @robot.logger.info "Not an alert."

--- a/src/victorops.coffee
+++ b/src/victorops.coffee
@@ -187,6 +187,7 @@ class VictorOps extends Adapter
       for item in data.PAYLOAD.TIMELINE_LIST
         try
           if item.ALERT
+            @robot.brain.set item.ALERT["INCIDENT_NAME"], item.ALERT
             @robot.emit "alert", item.ALERT
             @rcvVOEvent 'alert', item.ALERT
         catch


### PR DESCRIPTION
Being able to access an alert from a script would be nice. By emitting `alert` when an alert happens, scripts can act on it.